### PR TITLE
chore(user): refatorar dependências e adicionar cancellation tokens

### DIFF
--- a/src/Fiap.CloudGames.Api/Controllers/UsersController.cs
+++ b/src/Fiap.CloudGames.Api/Controllers/UsersController.cs
@@ -1,8 +1,6 @@
 using Fiap.CloudGames.Application.Users.Dtos;
 using Fiap.CloudGames.Application.Users.Services;
-using Fiap.CloudGames.Domain.Shared.Interfaces;
 using Fiap.CloudGames.Domain.Users.Enums;
-using Fiap.CloudGames.Infrastructure.Auth;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
@@ -14,35 +12,34 @@ namespace Fiap.CloudGames.Api.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
-public class UsersController(IUserService userService, IEmailService emailService, JwtService jwtService) : ControllerBase
+public class UsersController(IUserService userService) : ControllerBase
 {
 	private readonly IUserService _userService = userService;
-	private readonly IEmailService _emailService = emailService;
-	private readonly JwtService _jwtService = jwtService;
 
 	/// <summary>
 	/// Autentica usuário e retorna um JWT.
 	/// </summary>
 	/// <param name="dto">DTO com email e senha.</param>
+	/// <param name="ct"></param>
 	/// <returns>JWT token.</returns>
 	[HttpPost("login")]
 	[AllowAnonymous]
-	public async Task<IActionResult> Login([FromBody] LoginDto dto)
+	public async Task<IActionResult> Login([FromBody] LoginDto dto, CancellationToken ct)
 	{
-		var user = await _userService.AuthenticateAsync(dto.Email, dto.Password);
-		if (user == null) return Unauthorized(new { message = "Credenciais inválidas." });
-		var jwt = _jwtService.GenerateToken(user.Id, user.Name, user.Email, user.Role.ToString());
+		var jwt = await _userService.AuthenticateAsync(dto.Email, dto.Password, ct);
+		if (jwt == null) return Unauthorized(new { message = "Credenciais inválidas." });
 		return Ok(new { token = jwt });
 	}
 
 	/// <summary>
 	/// Lista todos os usuários (necessário role Administrator).
+	/// <param name="ct"></param>
 	/// </summary>
 	[HttpGet]
 	[Authorize(Roles = nameof(UserRole.Administrator))]
-	public async Task<IActionResult> GetAll()
+	public async Task<IActionResult> GetAll(CancellationToken ct)
 	{
-		var all = await _userService.GetAllAsync();
+		var all = await _userService.GetAllAsync(ct);
 		return Ok(all);
 	}
 
@@ -50,11 +47,12 @@ public class UsersController(IUserService userService, IEmailService emailServic
 	/// Obtém um usuário pelo identificador (necessário role Administrator).
 	/// </summary>
 	/// <param name="id">Identificador do usuário (GUID).</param>
+	/// <param name="ct"></param>
 	[HttpGet("{id:guid}")]
 	[Authorize(Roles = nameof(UserRole.Administrator))]
-	public async Task<IActionResult> GetById(Guid id)
+	public async Task<IActionResult> GetById(Guid id, CancellationToken ct)
 	{
-		var user = await _userService.GetByIdAsync(id);
+		var user = await _userService.GetByIdAsync(id, ct);
 		if (user == null) return NotFound(new { message = "Usuário não encontrado." });
 		return Ok(user);
 	}
@@ -62,14 +60,15 @@ public class UsersController(IUserService userService, IEmailService emailServic
 	/// <summary>
 	/// Obtém os dados do usuário autenticado (a partir do token JWT).
 	/// </summary>
+	/// <param name="ct"></param>
 	[HttpGet("me")]
 	[Authorize]
-	public async Task<IActionResult> GetMe()
+	public async Task<IActionResult> GetMe(CancellationToken ct)
 	{
 		var email = User.FindFirstValue(ClaimTypes.Email);
 		if (string.IsNullOrWhiteSpace(email)) return Unauthorized(new { message = "Email não presente no token." });
 
-		var user = await _userService.GetByEmailAsync(email);
+		var user = await _userService.GetByEmailAsync(email, ct);
 		if (user == null) return Unauthorized(new { message = "Usuário não encontrado ou token inválido." });
 		return Ok(user);
 	}
@@ -78,14 +77,13 @@ public class UsersController(IUserService userService, IEmailService emailServic
 	/// Registra um novo usuário (self-signup).
 	/// </summary>
 	/// <param name="dto">Dados de registro (nome, email, senha).</param>
+	/// <param name="ct"></param>
 	/// <returns>Usuário criado.</returns>
 	[HttpPost("register")]
 	[AllowAnonymous]
-	public async Task<IActionResult> Register([FromBody] UserRegisterDto dto)
+	public async Task<IActionResult> Register([FromBody] UserRegisterDto dto, CancellationToken ct)
 	{
-		var created = await _userService.RegisterAsync(dto);
-		var token = await _userService.GenerateEmailConfirmationAsync(created.Email);
-		await _emailService.SendEmailAsync(created.Email, "Confirmação de email", $"Seu token de confirmação: {token}");
+		var created = await _userService.RegisterAsync(dto, ct);
 		return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
 	}
 
@@ -93,24 +91,26 @@ public class UsersController(IUserService userService, IEmailService emailServic
 	/// Confirma o email de um usuário com token.
 	/// </summary>
 	/// <param name="dto">DTO contendo o token de confirmação.</param>
+	/// <param name="ct"></param>
 	[HttpPost("confirm")]
 	[AllowAnonymous]
-	public async Task<IActionResult> Confirm([FromBody] ConfirmEmailDto dto)
+	public async Task<IActionResult> Confirm([FromBody] ConfirmEmailDto dto, CancellationToken ct)
 	{
-		var ok = await _userService.ConfirmEmailAsync(dto.Token);
+		var ok = await _userService.ConfirmEmailAsync(dto.Token, ct);
 		if (!ok) return BadRequest(new { message = "Token inválido ou expirado." });
 		return Ok(new { message = "Email confirmado com sucesso." });
 	}
 
-    /// <summary>
-    /// Solicita um token de redefinição de senha para o email informado.
-    /// </summary>
-    /// <param name="dto">DTO com o email.</param>
-    //  SECURITY: avaliar trocar para 202 + resposta genérica em produção
-    [HttpPost("forgot-password")]
-    public async Task<IActionResult> ForgotPassword([FromBody] ForgotPasswordDto dto)
+	/// <summary>
+	/// Solicita um token de redefinição de senha para o email informado.
+	/// </summary>
+	/// <param name="dto">DTO com o email.</param>
+	/// <param name="ct"></param>
+	//  SECURITY: avaliar trocar para 202 + resposta genérica em produção
+	[HttpPost("forgot-password")]
+    public async Task<IActionResult> ForgotPassword([FromBody] ForgotPasswordDto dto, CancellationToken ct)
 	{
-		var token = await _userService.GeneratePasswordResetAsync(dto.Email);
+		var token = await _userService.GeneratePasswordResetAsync(dto.Email, ct);
 		return Ok(new { resetToken = token });
 	}
 
@@ -118,11 +118,12 @@ public class UsersController(IUserService userService, IEmailService emailServic
 	/// Redefine a senha utilizando token enviado por email.
 	/// </summary>
 	/// <param name="dto">DTO com token e nova senha.</param>
+	/// <param name="ct"></param>
 	[HttpPost("reset-password")]
 	[AllowAnonymous]
-	public async Task<IActionResult> Reset([FromBody] ResetPasswordDto dto)
+	public async Task<IActionResult> Reset([FromBody] ResetPasswordDto dto, CancellationToken ct)
 	{
-		var ok = await _userService.ResetPasswordAsync(dto.Token, dto.NewPassword);
+		var ok = await _userService.ResetPasswordAsync(dto.Token, dto.NewPassword, ct);
 		if (!ok) return BadRequest(new { message = "Token de redefinição inválido ou expirado." });
 		return Ok(new { message = "Senha redefinida com sucesso." });
 	}
@@ -131,24 +132,25 @@ public class UsersController(IUserService userService, IEmailService emailServic
 	/// Cria um usuário com privilégios administrativos (necessário role Administrator).
 	/// </summary>
 	/// <param name="dto">DTO contendo nome, email e role.</param>
+	/// <param name="ct"></param>
 	[HttpPost]
 	[Authorize(Roles = nameof(UserRole.Administrator))]
-	public async Task<IActionResult> CreateByAdmin([FromBody] AdminUserCreateDto dto)
+	public async Task<IActionResult> CreateByAdmin([FromBody] AdminUserCreateDto dto, CancellationToken ct)
 	{
-		var created = await _userService.CreateByAdminAsync(dto);
-		var token = await _userService.GenerateFirstAccessAsync(created.Email);
-		await _emailService.SendEmailAsync(created.Email, "Acesso inicial - defina sua senha", $"Utilize este token para definir sua senha inicial: {token}");
+		var created = await _userService.CreateByAdminAsync(dto, ct);
 		return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
 	}
 
 	/// <summary>
 	/// Endpoint para primeiro acesso: define a senha usando o token recebido por email.
 	/// </summary>
+	/// <param name="dto"></param>
+	/// <param name="ct"></param>
 	[HttpPost("first-access")]
 	[AllowAnonymous]
-	public async Task<IActionResult> FirstAccess([FromBody] FirstAccessDto dto)
+	public async Task<IActionResult> FirstAccess([FromBody] FirstAccessDto dto, CancellationToken ct)
 	{
-		var ok = await _userService.FirstAccessAsync(dto.Token, dto.NewPassword);
+		var ok = await _userService.FirstAccessAsync(dto.Token, dto.NewPassword, ct);
 		if (!ok) return BadRequest(new { message = "Token inválido ou expirado." });
 		return Ok(new { message = "Senha definida com sucesso." });
 	}
@@ -157,11 +159,12 @@ public class UsersController(IUserService userService, IEmailService emailServic
 	/// Atualiza um usuário (necessário role Administrator).
 	/// </summary>
 	/// <param name="dto">DTO contendo campos a serem atualizados.</param>
+	/// <param name="ct"></param>
 	[HttpPut]
 	[Authorize(Roles = nameof(UserRole.Administrator))]
-	public async Task<IActionResult> Update([FromBody] AdminUserUpdateDto dto)
+	public async Task<IActionResult> Update([FromBody] AdminUserUpdateDto dto, CancellationToken ct)
 	{
-		var updated = await _userService.UpdateAsync(dto);
+		var updated = await _userService.UpdateAsync(dto, ct);
 		if (updated == null) return NotFound(new { message = "Usuário não encontrado." });
 		return Ok(updated);
 	}
@@ -170,22 +173,25 @@ public class UsersController(IUserService userService, IEmailService emailServic
 	/// Soft-delete (marca usuário como Deleted) (necessário role Administrator).
 	/// </summary>
 	/// <param name="id">Identificador do usuário (GUID).</param>
+	/// <param name="ct"></param>
 	[HttpDelete("{id:guid}")]
 	[Authorize(Roles = nameof(UserRole.Administrator))]
-	public async Task<IActionResult> Delete(Guid id)
+	public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
 	{
-		await _userService.DeleteAsync(id);
+		await _userService.DeleteAsync(id, ct);
 		return NoContent();
 	}
 
 	/// <summary>
 	/// Restaura um usuário deletado (necessário role Administrator).
 	/// </summary>
+	/// <param name="id"></param>
+	/// <param name="ct"></param>
 	[HttpPost("{id:guid}/restore")]
 	[Authorize(Roles = nameof(UserRole.Administrator))]
-	public async Task<IActionResult> Restore(Guid id)
+	public async Task<IActionResult> Restore(Guid id, CancellationToken ct)
 	{
-		await _userService.RestoreAsync(id);
+		await _userService.RestoreAsync(id, ct);
 		return Ok(new { message = "Usuário restaurado." });
 	}
 }

--- a/src/Fiap.CloudGames.Api/Program.cs
+++ b/src/Fiap.CloudGames.Api/Program.cs
@@ -8,6 +8,7 @@ using Fiap.CloudGames.Domain.Orders.Repositories;
 using Fiap.CloudGames.Domain.Shared.Interfaces;
 using Fiap.CloudGames.Domain.Shared.Options;
 using Fiap.CloudGames.Domain.UserGamesLibrary.Repositories;
+using Fiap.CloudGames.Domain.Users.Interfaces;
 using Fiap.CloudGames.Domain.Users.Repositories;
 using Fiap.CloudGames.Infrastructure.Auth;
 using Fiap.CloudGames.Infrastructure.Email;
@@ -72,7 +73,7 @@ builder.Services.AddOptions<AdminUserOptions>()
     .ValidateOnStart();
 
 // Add services to the container.
-builder.Services.AddSingleton<JwtService>();
+builder.Services.AddSingleton<IJwtService, JwtService>();
 
 builder.Services.AddScoped<IUserRepository, UserRepository>();
 builder.Services.AddScoped<IUserService, UserService>();
@@ -183,9 +184,11 @@ using (var scope = app.Services.CreateScope())
 
     if (app.Environment.IsDevelopment())
     {
-        var seeder = scope.ServiceProvider.GetRequiredService<IUserSeeder>();
-        await seeder.SeedAsync();
-    }
+		var seeder = scope.ServiceProvider.GetRequiredService<IUserSeeder>();
+		using var cts = CancellationTokenSource.CreateLinkedTokenSource(app.Lifetime.ApplicationStopping);
+		cts.CancelAfter(TimeSpan.FromSeconds(30));
+		await seeder.SeedAsync(cts.Token);
+	}
 }
 
 // Configure the HTTP request pipeline.

--- a/src/Fiap.CloudGames.Application/Users/Services/IUserService.cs
+++ b/src/Fiap.CloudGames.Application/Users/Services/IUserService.cs
@@ -4,24 +4,24 @@ namespace Fiap.CloudGames.Application.Users.Services;
 
 public interface IUserService
 {
-	Task<IReadOnlyList<UserDto>> GetAllAsync();
-	Task<UserDto?> GetByIdAsync(Guid id);
-	Task<UserDto?> GetByEmailAsync(string email);
+	Task<IReadOnlyList<UserDto>> GetAllAsync(CancellationToken ct);
+	Task<UserDto?> GetByIdAsync(Guid id, CancellationToken ct);
+	Task<UserDto?> GetByEmailAsync(string email, CancellationToken ct);
 
-	Task<UserDto?> AuthenticateAsync(string email, string password);
+	Task<string?> AuthenticateAsync(string email, string password, CancellationToken ct);
 
-	Task<UserDto> RegisterAsync(UserRegisterDto dto);
-	Task<string> GenerateEmailConfirmationAsync(string email);
-	Task<bool> ConfirmEmailAsync(string token);
+	Task<UserDto> RegisterAsync(UserRegisterDto dto, CancellationToken ct);
+	Task<string> GenerateEmailConfirmationAsync(string email, CancellationToken ct);
+	Task<bool> ConfirmEmailAsync(string token, CancellationToken ct);
 
-	Task<string> GeneratePasswordResetAsync(string email);
-	Task<bool> ResetPasswordAsync(string token, string newPassword);
+	Task<string> GeneratePasswordResetAsync(string email, CancellationToken ct);
+	Task<bool> ResetPasswordAsync(string token, string newPassword, CancellationToken ct);
 
-	Task<string> GenerateFirstAccessAsync(string email);
-	Task<bool> FirstAccessAsync(string token, string newPassword);
+	Task<string> GenerateFirstAccessAsync(string email, CancellationToken ct);
+	Task<bool> FirstAccessAsync(string token, string newPassword, CancellationToken ct);
 
-	Task<UserDto> CreateByAdminAsync(AdminUserCreateDto dto);
-	Task<UserDto?> UpdateAsync(AdminUserUpdateDto dto);
-	Task DeleteAsync(Guid id);
-	Task RestoreAsync(Guid id);
+	Task<UserDto> CreateByAdminAsync(AdminUserCreateDto dto, CancellationToken ct);
+	Task<UserDto?> UpdateAsync(AdminUserUpdateDto dto, CancellationToken ct);
+	Task DeleteAsync(Guid id, CancellationToken ct);
+	Task RestoreAsync(Guid id, CancellationToken ct);
 }

--- a/src/Fiap.CloudGames.Application/Users/Services/UserService.cs
+++ b/src/Fiap.CloudGames.Application/Users/Services/UserService.cs
@@ -1,121 +1,134 @@
 ﻿using Fiap.CloudGames.Application.Users.Dtos;
+using Fiap.CloudGames.Domain.Shared.Interfaces;
 using Fiap.CloudGames.Domain.Shared.Options;
 using Fiap.CloudGames.Domain.Users.Entities;
 using Fiap.CloudGames.Domain.Users.Enums;
+using Fiap.CloudGames.Domain.Users.Interfaces;
 using Fiap.CloudGames.Domain.Users.Repositories;
 using Microsoft.Extensions.Options;
 
 namespace Fiap.CloudGames.Application.Users.Services;
 
-public class UserService(IUserRepository repository, IOptions<AdminUserOptions> adminOptions) : IUserService
+public class UserService(IUserRepository repository, IJwtService jwtService, IEmailService emailService, IOptions<AdminUserOptions> adminOptions) : IUserService
 {
 	private readonly IUserRepository _repository = repository;
-	private readonly string? _superEmail = adminOptions?.Value?.Email?.ToLowerInvariant();
+	private readonly IJwtService _jwtService = jwtService;
+	private readonly IEmailService _emailService = emailService;
+	private readonly string _superEmail = adminOptions.Value.Email.ToLowerInvariant();
 
-	public async Task<IReadOnlyList<UserDto>> GetAllAsync()
+	public async Task<IReadOnlyList<UserDto>> GetAllAsync(CancellationToken ct)
 	{
-		var all = await _repository.GetAllAsync();
+		var all = await _repository.GetAllAsync(ct);
 		return all.Select(Map).ToList();
 	}
 
-	public async Task<UserDto?> GetByIdAsync(Guid id)
+	public async Task<UserDto?> GetByIdAsync(Guid id, CancellationToken ct)
 	{
-		var user = await _repository.GetByIdAsync(id);
+		var user = await _repository.GetByIdAsync(id, ct);
 		return user == null ? null : Map(user);
 	}
 
-	public async Task<UserDto?> GetByEmailAsync(string email)
+	public async Task<UserDto?> GetByEmailAsync(string email, CancellationToken ct)
 	{
-		var user = await _repository.GetByEmailAsync(email);
+		var user = await _repository.GetByEmailAsync(email, ct);
 		return user == null ? null : Map(user);
 	}
 
-	public async Task<UserDto?> AuthenticateAsync(string email, string password)
+	public async Task<string?> AuthenticateAsync(string email, string password, CancellationToken ct)
 	{
-		var user = await _repository.GetByEmailAsync(email);
+		var user = await _repository.GetByEmailAsync(email, ct);
 		if (user == null) return null;
 		if (!user.VerifyPassword(password)) return null;
 		if (!user.EmailConfirmed) return null;
 		if (user.Status != UserStatus.Active) return null;
-		return Map(user);
+		var jwt = _jwtService.GenerateToken(user.Id, user.Name, user.Email, user.Role.ToString(), ct);
+		return jwt;
 	}
 
-	public async Task<UserDto> RegisterAsync(UserRegisterDto dto)
+	public async Task<UserDto> RegisterAsync(UserRegisterDto dto, CancellationToken ct)
 	{
-		var existing = await _repository.GetByEmailAsync(dto.Email);
+		var existing = await _repository.GetByEmailAsync(dto.Email, ct);
 		if (existing != null) throw new ArgumentException("Usuário com este e-mail já existe.");
 
 		var user = User.Create(dto.Name, dto.Email, dto.Password, UserRole.User, UserStatus.Inactive);
-		await _repository.AddAsync(user);
+		await _repository.AddAsync(user, ct);
+
+		var token = await GenerateEmailConfirmationAsync(user.Email, ct);
+		await _emailService.SendEmailAsync(user.Email, "Confirmação de email", $"Seu token de confirmação: {token}");
+
 		return Map(user);
 	}
 
-	public async Task<string> GenerateEmailConfirmationAsync(string email)
+	public async Task<string> GenerateEmailConfirmationAsync(string email, CancellationToken ct)
 	{
-		var user = await _repository.GetByEmailAsync(email) ?? throw new ArgumentException("Usuário não encontrado.");
+		var user = await _repository.GetByEmailAsync(email, ct) ?? throw new ArgumentException("Usuário não encontrado.");
 		var token = user.GenerateEmailConfirmationToken();
-		await _repository.UpdateAsync(user);
+		await _repository.UpdateAsync(user, ct);
 		return token;
 	}
 
-	public async Task<bool> ConfirmEmailAsync(string token)
+	public async Task<bool> ConfirmEmailAsync(string token, CancellationToken ct)
 	{
-		var user = await _repository.GetByConfirmationTokenAsync(token);
+		var user = await _repository.GetByConfirmationTokenAsync(token, ct);
 		if (user == null) return false;
 		var result = user.ConfirmEmail(token);
-		if (result) await _repository.UpdateAsync(user);
+		if (result) await _repository.UpdateAsync(user, ct);
 		return result;
 	}
 
-	public async Task<string> GeneratePasswordResetAsync(string email)
+	public async Task<string> GeneratePasswordResetAsync(string email, CancellationToken ct)
 	{
-		var user = await _repository.GetByEmailAsync(email) ?? throw new ArgumentException("Usuário não encontrado.");
+		var user = await _repository.GetByEmailAsync(email, ct) ?? throw new ArgumentException("Usuário não encontrado.");
 		var token = user.GeneratePasswordResetToken(TimeSpan.FromHours(1));
-		await _repository.UpdateAsync(user);
+		await _repository.UpdateAsync(user, ct);
 		return token;
 	}
 
-	public async Task<bool> ResetPasswordAsync(string token, string newPassword)
+	public async Task<bool> ResetPasswordAsync(string token, string newPassword, CancellationToken ct)
 	{
-		var user = await _repository.GetByPasswordResetTokenAsync(token);
+		var user = await _repository.GetByPasswordResetTokenAsync(token, ct);
 		if (user == null) return false;
 		var result = user.ResetPassword(token, newPassword);
-		if (result) await _repository.UpdateAsync(user);
+		if (result) await _repository.UpdateAsync(user, ct);
 		return result;
 	}
 
-	public async Task<string> GenerateFirstAccessAsync(string email)
+	public async Task<string> GenerateFirstAccessAsync(string email, CancellationToken ct)
 	{
-		var user = await _repository.GetByEmailAsync(email) ?? throw new ArgumentException("Usuário não encontrado.");
+		var user = await _repository.GetByEmailAsync(email, ct) ?? throw new ArgumentException("Usuário não encontrado.");
 		var token = user.GenerateFirstAccessToken(TimeSpan.FromHours(24));
-		await _repository.UpdateAsync(user);
+		await _repository.UpdateAsync(user, ct);
 		return token;
 	}
 
-	public async Task<bool> FirstAccessAsync(string token, string newPassword)
+	public async Task<bool> FirstAccessAsync(string token, string newPassword, CancellationToken ct)
 	{
-		var user = await _repository.GetByFirstAccessTokenAsync(token);
+		var user = await _repository.GetByFirstAccessTokenAsync(token, ct);
 		if (user == null) return false;
 		var result = user.CompleteFirstAccess(token, newPassword);
-		if (result) await _repository.UpdateAsync(user);
+		if (result) await _repository.UpdateAsync(user, ct);
 		return result;
 	}
 
-	public async Task<UserDto> CreateByAdminAsync(AdminUserCreateDto dto)
+	public async Task<UserDto> CreateByAdminAsync(AdminUserCreateDto dto, CancellationToken ct)
 	{
-		var existing = await _repository.GetByEmailAsync(dto.Email);
+		var existing = await _repository.GetByEmailAsync(dto.Email, ct);
 		if (existing != null) throw new ArgumentException("Usuário com este e-mail já existe.");
 
 		// The user will set their own password via first access flow, but we need to have a valid password at creation time.
 		var tempPassword = GenerateTemporaryPassword();
 		var user = User.Create(dto.Name, dto.Email, tempPassword, dto.Role, UserStatus.Inactive);
-		await _repository.AddAsync(user);
+		await _repository.AddAsync(user, ct);
+
+		var token = await GenerateFirstAccessAsync(user.Email, ct);
+		await _emailService.SendEmailAsync(user.Email, "Acesso inicial - defina sua senha", $"Utilize este token para definir sua senha inicial: {token}");
+
 		return Map(user);
 	}
 
-	public async Task<UserDto?> UpdateAsync(AdminUserUpdateDto dto)
+	public async Task<UserDto?> UpdateAsync(AdminUserUpdateDto dto, CancellationToken ct)
 	{
-		var user = await _repository.GetByIdAsync(dto.Id);
+		var user = await _repository.GetByIdAsync(dto.Id, ct);
 		if (user == null) return null;
 
 		// Prevent modifying the seeded super admin
@@ -128,7 +141,7 @@ public class UserService(IUserRepository repository, IOptions<AdminUserOptions> 
 		{
 			if (!string.Equals(user.Email.Address, dto.Email, StringComparison.OrdinalIgnoreCase))
 			{
-				var other = await _repository.GetByEmailAsync(dto.Email);
+				var other = await _repository.GetByEmailAsync(dto.Email, ct);
 				if (other != null && other.Id != user.Id) throw new ArgumentException("Usuário com este e-mail já existe.");
 			}
 			user.UpdateEmail(dto.Email);
@@ -141,13 +154,13 @@ public class UserService(IUserRepository repository, IOptions<AdminUserOptions> 
 			if (dto.EmailConfirmed.Value) user.MarkEmailConfirmed(); else user.MarkEmailUnconfirmed();
 		}
 
-		await _repository.UpdateAsync(user);
+		await _repository.UpdateAsync(user, ct);
 		return Map(user);
 	}
 
-	public async Task DeleteAsync(Guid id)
+	public async Task DeleteAsync(Guid id, CancellationToken ct)
 	{
-		var user = await _repository.GetByIdAsync(id);
+		var user = await _repository.GetByIdAsync(id, ct);
 		if (user == null) return;
 
 		// Prevent deleting the seeded super admin
@@ -155,15 +168,15 @@ public class UserService(IUserRepository repository, IOptions<AdminUserOptions> 
 			throw new InvalidOperationException("O usuário administrativo principal não pode ser removido.");
 
 		user.SoftDelete();
-		await _repository.UpdateAsync(user);
+		await _repository.UpdateAsync(user, ct);
 	}
 
-	public async Task RestoreAsync(Guid id)
+	public async Task RestoreAsync(Guid id, CancellationToken ct)
 	{
-		var user = await _repository.GetByIdAsync(id);
+		var user = await _repository.GetByIdAsync(id, ct);
 		if (user == null) return;
 		user.Restore();
-		await _repository.UpdateAsync(user);
+		await _repository.UpdateAsync(user, ct);
 	}
 
 	private static UserDto Map(User user) => new(user.Id, user.Name, user.Email.Address, user.Role, user.EmailConfirmed, user.CreatedAt);

--- a/src/Fiap.CloudGames.Domain/Users/Interfaces/IJwtService.cs
+++ b/src/Fiap.CloudGames.Domain/Users/Interfaces/IJwtService.cs
@@ -1,0 +1,9 @@
+﻿using Fiap.CloudGames.Domain.Users.Entities;
+
+namespace Fiap.CloudGames.Domain.Users.Interfaces;
+
+public interface IJwtService
+{
+	string GenerateToken(Guid id, string name, string email, string role, CancellationToken ct);
+	string GenerateToken(User user, CancellationToken ct);
+}

--- a/src/Fiap.CloudGames.Domain/Users/Repositories/IUserRepository.cs
+++ b/src/Fiap.CloudGames.Domain/Users/Repositories/IUserRepository.cs
@@ -4,13 +4,13 @@ namespace Fiap.CloudGames.Domain.Users.Repositories;
 
 public interface IUserRepository
 {
-	Task<IReadOnlyList<User>> GetAllAsync();
-	Task<User?> GetByIdAsync(Guid id);
-	Task<User?> GetByEmailAsync(string email);
-	Task<User?> GetByConfirmationTokenAsync(string token);
-	Task<User?> GetByPasswordResetTokenAsync(string token);
-	Task<User?> GetByFirstAccessTokenAsync(string token);
+	Task<IReadOnlyList<User>> GetAllAsync(CancellationToken ct);
+	Task<User?> GetByIdAsync(Guid id, CancellationToken ct);
+	Task<User?> GetByEmailAsync(string email, CancellationToken ct);
+	Task<User?> GetByConfirmationTokenAsync(string token, CancellationToken ct);
+	Task<User?> GetByPasswordResetTokenAsync(string token, CancellationToken ct);
+	Task<User?> GetByFirstAccessTokenAsync(string token, CancellationToken ct);
 
-	Task AddAsync(User user);
-	Task UpdateAsync(User user);
+	Task AddAsync(User user, CancellationToken ct);
+	Task UpdateAsync(User user, CancellationToken ct);
 }

--- a/src/Fiap.CloudGames.Infrastructure/Auth/JwtService.cs
+++ b/src/Fiap.CloudGames.Infrastructure/Auth/JwtService.cs
@@ -1,4 +1,5 @@
 ﻿using Fiap.CloudGames.Domain.Users.Entities;
+using Fiap.CloudGames.Domain.Users.Interfaces;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
@@ -7,11 +8,11 @@ using System.Text;
 
 namespace Fiap.CloudGames.Infrastructure.Auth;
 
-public class JwtService(IOptions<JwtOptions> options)
+public class JwtService(IOptions<JwtOptions> options) : IJwtService
 {
 	private readonly JwtOptions _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
 
-	public string GenerateToken(Guid id, string name, string email, string role)
+	public string GenerateToken(Guid id, string name, string email, string role, CancellationToken ct)
 	{
 		var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_options.Secret));
 		var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
@@ -36,5 +37,5 @@ public class JwtService(IOptions<JwtOptions> options)
 		return new JwtSecurityTokenHandler().WriteToken(token);
 	}
 
-	public string GenerateToken(User user) => GenerateToken(user.Id, user.Name, user.Email.Address, user.Role.ToString());
+	public string GenerateToken(User user, CancellationToken ct) => GenerateToken(user.Id, user.Name, user.Email.Address, user.Role.ToString(), ct);
 }

--- a/src/Fiap.CloudGames.Infrastructure/Users/Repositories/InMemoryUserRepository.cs
+++ b/src/Fiap.CloudGames.Infrastructure/Users/Repositories/InMemoryUserRepository.cs
@@ -7,43 +7,43 @@ public class InMemoryUserRepository : IUserRepository
 {
     private static readonly List<User> _users = [];
 
-	public Task<User?> GetByIdAsync(Guid id)
+	public Task<User?> GetByIdAsync(Guid id, CancellationToken ct)
 	{
 		return Task.FromResult(_users.FirstOrDefault(u => u.Id == id));
 	}
 
-	public Task<IReadOnlyList<User>> GetAllAsync()
+	public Task<IReadOnlyList<User>> GetAllAsync(CancellationToken ct)
 	{
 		return Task.FromResult((IReadOnlyList<User>)[.. _users]);
 	}
 
-	public Task<User?> GetByEmailAsync(string email)
+	public Task<User?> GetByEmailAsync(string email, CancellationToken ct)
 	{
 		return Task.FromResult(_users.FirstOrDefault(u => string.Equals(u.Email.Address, email, StringComparison.OrdinalIgnoreCase)));
 	}
 
-	public Task<User?> GetByConfirmationTokenAsync(string token)
+	public Task<User?> GetByConfirmationTokenAsync(string token, CancellationToken ct)
 	{
 		return Task.FromResult(_users.FirstOrDefault(u => u.ConfirmationToken == token));
 	}
 
-	public Task<User?> GetByPasswordResetTokenAsync(string token)
+	public Task<User?> GetByPasswordResetTokenAsync(string token, CancellationToken ct)
 	{
 		return Task.FromResult(_users.FirstOrDefault(u => u.PasswordResetToken == token));
 	}
 
-	public Task<User?> GetByFirstAccessTokenAsync(string token)
+	public Task<User?> GetByFirstAccessTokenAsync(string token, CancellationToken ct)
 	{
 		return Task.FromResult(_users.FirstOrDefault(u => u.FirstAccessToken == token));
 	}
 
-	public Task AddAsync(User user)
+	public Task AddAsync(User user, CancellationToken ct)
 	{
 		_users.Add(user);
 		return Task.CompletedTask;
 	}
 
-	public Task UpdateAsync(User user)
+	public Task UpdateAsync(User user, CancellationToken ct)
 	{
 		var idx = _users.FindIndex(u => u.Id == user.Id);
 		if (idx >= 0) _users[idx] = user;

--- a/src/Fiap.CloudGames.Infrastructure/Users/Repositories/UserRepository.cs
+++ b/src/Fiap.CloudGames.Infrastructure/Users/Repositories/UserRepository.cs
@@ -14,49 +14,49 @@ public class UserRepository(AppDbContext context) : IUserRepository
 {
 	private readonly AppDbContext _context = context;
 
-	public async Task<IReadOnlyList<User>> GetAllAsync()
+	public async Task<IReadOnlyList<User>> GetAllAsync(CancellationToken ct)
 	{
-		return await _context.Users.ToListAsync();
+		return await _context.Users.ToListAsync(ct);
 	}
 
-	public async Task<User?> GetByIdAsync(Guid id)
+	public async Task<User?> GetByIdAsync(Guid id, CancellationToken ct)
 	{
-		return await _context.Users.FindAsync(id);
+		return await _context.Users.FindAsync(new object?[] { id }, ct);
 	}
 
-	public async Task<User?> GetByEmailAsync(string email)
-	{
-		return await _context.Users
-			.FirstOrDefaultAsync(u => u.Email.Address.ToLower() == email.ToLower());
-	}
-
-	public async Task<User?> GetByConfirmationTokenAsync(string token)
+	public async Task<User?> GetByEmailAsync(string email, CancellationToken ct)
 	{
 		return await _context.Users
-			.FirstOrDefaultAsync(u => u.ConfirmationToken == token);
+			.FirstOrDefaultAsync(u => u.Email.Address.ToLower() == email.ToLower(), ct);
 	}
 
-	public async Task<User?> GetByPasswordResetTokenAsync(string token)
+	public async Task<User?> GetByConfirmationTokenAsync(string token, CancellationToken ct)
 	{
 		return await _context.Users
-			.FirstOrDefaultAsync(u => u.PasswordResetToken == token);
+			.FirstOrDefaultAsync(u => u.ConfirmationToken == token, ct);
 	}
 
-	public async Task<User?> GetByFirstAccessTokenAsync(string token)
+	public async Task<User?> GetByPasswordResetTokenAsync(string token, CancellationToken ct)
 	{
 		return await _context.Users
-			.FirstOrDefaultAsync(u => u.FirstAccessToken == token);
+			.FirstOrDefaultAsync(u => u.PasswordResetToken == token, ct);
 	}
 
-	public async Task AddAsync(User user)
+	public async Task<User?> GetByFirstAccessTokenAsync(string token, CancellationToken ct)
 	{
-		await _context.Users.AddAsync(user);
-		await _context.SaveChangesAsync();
+		return await _context.Users
+			.FirstOrDefaultAsync(u => u.FirstAccessToken == token, ct);
 	}
 
-	public async Task UpdateAsync(User user)
+	public async Task AddAsync(User user, CancellationToken ct)
+	{
+		await _context.Users.AddAsync(user, ct);
+		await _context.SaveChangesAsync(ct);
+	}
+
+	public async Task UpdateAsync(User user, CancellationToken ct)
 	{
 		_context.Users.Update(user);
-		await _context.SaveChangesAsync();
+		await _context.SaveChangesAsync(ct);
 	}
 }

--- a/src/Fiap.CloudGames.Infrastructure/Users/Seeders/IUserSeeder.cs
+++ b/src/Fiap.CloudGames.Infrastructure/Users/Seeders/IUserSeeder.cs
@@ -4,5 +4,5 @@ namespace Fiap.CloudGames.Infrastructure.Users.Seeders;
 
 public interface IUserSeeder
 {
-    Task SeedAsync();
+    Task SeedAsync(CancellationToken ct);
 }

--- a/src/Fiap.CloudGames.Infrastructure/Users/Seeders/UserSeeder.cs
+++ b/src/Fiap.CloudGames.Infrastructure/Users/Seeders/UserSeeder.cs
@@ -11,10 +11,10 @@ public class UserSeeder(IUserRepository userRepository, IOptions<AdminUserOption
     private readonly IUserRepository _userRepository = userRepository;
     private readonly AdminUserOptions _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
 
-	public async Task SeedAsync()
+	public async Task SeedAsync(CancellationToken ct)
     {
         var adminEmail = _options.Email;
-        var existing = await _userRepository.GetByEmailAsync(adminEmail!);
+        var existing = await _userRepository.GetByEmailAsync(adminEmail, ct);
         if (existing is not null) return;
 
         var user = User.Create(
@@ -28,6 +28,6 @@ public class UserSeeder(IUserRepository userRepository, IOptions<AdminUserOption
         if (_options.EmailConfirmed)
             user.MarkEmailConfirmed();
 
-        await _userRepository.AddAsync(user);
+        await _userRepository.AddAsync(user, ct);
     }
 }


### PR DESCRIPTION
Este pull request melhora o fluxo de gerenciamento de usuários ao tornar os métodos assíncronos (com `CancellationToken`) e ao centralizar a lógica de negócio no `UserService`. As alterações aumentam a responsividade, confiabilidade e manutenibilidade da API.

**Refatoração do Controller e Service:**

* Actions do `UsersController` e métodos do `UserService` agora são assíncronos e aceitam `CancellationToken`, permitindo o cancelamento de solicitações.
* Lógica de negócio (envio de e-mail, geração de token) movida do controller para o serviço.

**Injeção de Dependência:**

* Serviço JWT registrado pela interface (`IJwtService`) para melhorar a abstração e testabilidade.

**Melhorias no Seeding:**

* Adicionado `CancellationToken` com timeout de 30 segundos ao seeding de desenvolvimento para evitar travamentos na inicialização.

**Limpezas Menores:**

* Remoção de `usings` não utilizados no `UsersController.cs`.